### PR TITLE
Fix wrong number of return arguments

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -48,5 +48,5 @@ func Count(path string) (int64, error) {
 		return numPackets, err
 	}
 
-	return numPackets
+	return numPackets, nil
 }


### PR DESCRIPTION
In a previous PR (#1) of mine, I forgot to change the last return statement in `Count()`. This patch fixes the issue.